### PR TITLE
Restrict qotd answer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,20 +12,30 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.QOTD"
         tools:targetApi="31">
+
+        <!-- LoginActivity as the first screen -->
         <activity
-            android:name=".MainActivity"
+            android:name=".LoginActivity"
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.QOTD">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- MainActivity (QOTD screen) -->
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.QOTD">
+        </activity>
+
         <activity android:name=".ReplaceQuestionActivity" />
         <activity android:name=".UserAnswersActivity" />
-        <activity android:name=".LoginActivity" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/qotd/LoginActivity.kt
+++ b/app/src/main/java/com/example/qotd/LoginActivity.kt
@@ -24,7 +24,7 @@ class LoginActivity : ComponentActivity() {
         setContent {
             QOTDTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    LoginScreen(modifier = Modifier.padding(innerPadding))
+                    LoginScreen(modifier = Modifier.padding(innerPadding), activity = this)
                 }
             }
         }
@@ -32,7 +32,7 @@ class LoginActivity : ComponentActivity() {
 }
 
 @Composable
-fun LoginScreen(modifier: Modifier) {
+fun LoginScreen(modifier: Modifier, activity: LoginActivity) {
     var email by remember { mutableStateOf("") }
     var password by remember { mutableStateOf("") }
     var message by remember { mutableStateOf("") }
@@ -45,9 +45,9 @@ fun LoginScreen(modifier: Modifier) {
             .addOnCompleteListener { task ->
                 if (task.isSuccessful) {
                     message = "Login Successful!"
-                    // Navigate to MainActivity after successful login
                     val intent = Intent(context, MainActivity::class.java)
                     context.startActivity(intent)
+                    activity.finish() // Prevent back navigation to Login screen
                 } else {
                     message = task.exception?.message ?: "Login Failed"
                 }
@@ -55,7 +55,7 @@ fun LoginScreen(modifier: Modifier) {
     }
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(16.dp),
         verticalArrangement = Arrangement.Center,

--- a/app/src/main/java/com/example/qotd/MainActivity.kt
+++ b/app/src/main/java/com/example/qotd/MainActivity.kt
@@ -12,16 +12,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.ui.unit.sp
 import com.example.qotd.ui.theme.QOTDTheme
 import com.google.firebase.firestore.FirebaseFirestore
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.CoroutineScope
-import androidx.compose.foundation.shape.RoundedCornerShape
 import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.SetOptions
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -29,6 +26,11 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        val currentUserId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
+
+        // Check if the user has already answered for today
+        checkIfAnsweredToday(currentUserId)
 
         setContent {
             QOTDTheme {
@@ -58,18 +60,33 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+
+    // Check if the user has already answered the QOTD today
+    private fun checkIfAnsweredToday(userId: String) {
+        if (userId.isNotEmpty()) {
+            val db = FirebaseFirestore.getInstance()
+            val userRef = db.collection("users").document(userId)
+
+            userRef.get().addOnSuccessListener { document ->
+                val answeredToday = document.getBoolean("answeredToday") ?: false
+                if (answeredToday) {
+                    // If already answered, go to UserAnswersActivity
+                    val intent = Intent(this, UserAnswersActivity::class.java)
+                    startActivity(intent)
+                    finish()  // Close the current activity to prevent going back
+                }
+            }
+        }
+    }
 }
 
 @Composable
 fun QuestionAnswerScreen(scope: CoroutineScope, snackbarHostState: SnackbarHostState) {
     var question by remember { mutableStateOf("Loading question...") }
     var userAnswer by remember { mutableStateOf("") }
-    var lastSubmittedAnswer by remember { mutableStateOf("") }
     var message by remember { mutableStateOf("") }
     val context = LocalContext.current
     val currentUserId = FirebaseAuth.getInstance().currentUser?.uid ?: ""
-
-    var seenQuestions by remember { mutableStateOf(emptyList<String>()) }
 
     // Function to fetch the daily question
     fun fetchQuestionOfTheDay() {
@@ -81,7 +98,6 @@ fun QuestionAnswerScreen(scope: CoroutineScope, snackbarHostState: SnackbarHostS
             if (document.exists()) {
                 val qotd = document.getString("question") ?: "Error loading question."
                 question = qotd
-                seenQuestions = seenQuestions + qotd
             } else {
                 db.collection("questions").get().addOnSuccessListener { result ->
                     val questionsList = result.documents.mapNotNull { it.getString("Question") }
@@ -90,7 +106,6 @@ fun QuestionAnswerScreen(scope: CoroutineScope, snackbarHostState: SnackbarHostS
                         dailyQuestionRef.set(mapOf("question" to randomQuestion))
 
                         question = randomQuestion
-                        seenQuestions = seenQuestions + randomQuestion
                     } else {
                         question = "No questions available."
                     }
@@ -116,8 +131,8 @@ fun QuestionAnswerScreen(scope: CoroutineScope, snackbarHostState: SnackbarHostS
                 context.startActivity(intent)
             },
             modifier = Modifier
-                .align(Alignment.TopStart) // Align to the top-left
-                .padding(top = 16.dp, start = 16.dp) // Add some padding to the top and left
+                .align(Alignment.TopStart)
+                .padding(top = 16.dp, start = 16.dp)
         ) {
             Text("Login")
         }
@@ -127,19 +142,19 @@ fun QuestionAnswerScreen(scope: CoroutineScope, snackbarHostState: SnackbarHostS
             modifier = Modifier
                 .fillMaxSize()
                 .padding(16.dp),
-            verticalArrangement = Arrangement.Center,  // Vertically center the content
-            horizontalAlignment = Alignment.CenterHorizontally  // Horizontally center the content
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            // QOTD Text
             Text(
                 text = question,
                 style = MaterialTheme.typography.headlineMedium,
-                modifier = Modifier.fillMaxWidth().align(Alignment.Start)
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.Start)
             )
 
             Spacer(modifier = Modifier.height(16.dp))
 
-            // Text input box for answer
             OutlinedTextField(
                 value = userAnswer,
                 onValueChange = { userAnswer = it },
@@ -149,10 +164,9 @@ fun QuestionAnswerScreen(scope: CoroutineScope, snackbarHostState: SnackbarHostS
 
             Spacer(modifier = Modifier.height(32.dp))
 
-            // Submit Button aligned to the right
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.End  // Align the submit button to the right
+                horizontalArrangement = Arrangement.End
             ) {
                 Button(
                     onClick = {
@@ -165,12 +179,12 @@ fun QuestionAnswerScreen(scope: CoroutineScope, snackbarHostState: SnackbarHostS
                                 scope.launch {
                                     snackbarHostState.showSnackbar(status)
                                 }
-                                lastSubmittedAnswer = userAnswer
                                 userAnswer = ""
                                 message = status
 
-                                // Navigate to the answers screen after submission
+                                // After submitting the answer, go to UserAnswersActivity
                                 val intent = Intent(context, UserAnswersActivity::class.java)
+                                intent.putExtra("isComingFromQOTD", true)
                                 context.startActivity(intent)
                             }
                         }
@@ -181,80 +195,16 @@ fun QuestionAnswerScreen(scope: CoroutineScope, snackbarHostState: SnackbarHostS
                 }
             }
         }
-
-        // Fetch random question for refresh button
-        fun fetchQuestion() {
-            FirebaseFirestore.getInstance().collection("questions")
-                .get()
-                .addOnSuccessListener { result ->
-                    val questionsList = result.documents.filter { it.id !in seenQuestions }
-
-                    if (questionsList.isNotEmpty()) {
-                        val randomQuestion = questionsList.random()
-                        question = randomQuestion.getString("Question") ?: "No question found"
-
-                        // Mark this question as seen
-                        seenQuestions = seenQuestions + randomQuestion.id
-                    } else {
-                        question = "No more new questions available."
-                    }
-                }
-        }
-
-        // Refresh button
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(12.dp),
-            contentAlignment = Alignment.BottomEnd
-        ) {
-            FilledIconButton(
-                onClick = { fetchQuestion() },
-                modifier = Modifier.size(80.dp),
-                colors = IconButtonDefaults.filledIconButtonColors(containerColor = MaterialTheme.colorScheme.primary)
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Refresh,
-                    contentDescription = "Refresh Question",
-                    modifier = Modifier.size(32.dp),
-                    tint = MaterialTheme.colorScheme.onPrimary
-                )
-            }
-        }
-
-        // Create new question button
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(12.dp),
-            contentAlignment = Alignment.BottomStart
-        ) {
-            FloatingActionButton(
-                onClick = {
-                    val intent = Intent(context, ReplaceQuestionActivity::class.java)
-                    context.startActivity(intent)
-                },
-                shape = RoundedCornerShape(16.dp),
-                modifier = Modifier.size(80.dp),
-                containerColor = MaterialTheme.colorScheme.primary
-            ) {
-                Icon(
-                    imageVector = Icons.Filled.Add,
-                    contentDescription = "Add Question",
-                    modifier = Modifier.size(36.dp),
-                    tint = MaterialTheme.colorScheme.onPrimary
-                )
-            }
-        }
     }
 }
 
-
+// Move the submitAnswer function outside of the composable to resolve scoping issues
 fun submitAnswer(userId: String, answer: String, callback: (String) -> Unit) {
     if (answer.isBlank()) {
         callback("Answer cannot be empty.")
         return
     }
+
     val answerData = hashMapOf(
         "userId" to userId,
         "displayName" to userId,
@@ -263,11 +213,26 @@ fun submitAnswer(userId: String, answer: String, callback: (String) -> Unit) {
         "comments" to emptyList<Map<String, Any>>(),
         "questionDate" to java.time.LocalDate.now().toString()
     )
+
     FirebaseFirestore.getInstance().collection("dailyAnswer").add(answerData)
         .addOnSuccessListener {
             callback("Answer submitted.")
+            markAnsweredToday(userId)  // Mark the user as answered for today
         }
         .addOnFailureListener {
             callback("Failed to submit answer.")
         }
+}
+
+// Mark the user as having answered today
+fun markAnsweredToday(userId: String) {
+    val userAnsweredData = hashMapOf(
+        "answeredToday" to true,
+        "lastAnsweredDate" to java.time.LocalDate.now().toString()
+    )
+
+    FirebaseFirestore.getInstance()
+        .collection("users")  // Assuming there's a 'users' collection
+        .document(userId)     // Document ID is the user ID
+        .set(userAnsweredData, SetOptions.merge())  // Merge to avoid overwriting other data
 }

--- a/app/src/main/java/com/example/qotd/UserAnswersActivity.kt
+++ b/app/src/main/java/com/example/qotd/UserAnswersActivity.kt
@@ -20,10 +20,21 @@ import androidx.compose.material.icons.outlined.FavoriteBorder
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
 
 class UserAnswersActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Check if the user came from the QOTD screen
+        val isComingFromQOTD = intent.getBooleanExtra("isComingFromQOTD", false)
+
+        // Disable back button if coming from QOTD screen
+        if (isComingFromQOTD) {
+            onBackPressedDispatcher.addCallback(this) {
+            }
+        }
 
         val questionDate = LocalDate.now() // Internal date format for Firebase (yyyy-MM-dd)
         val displayDate = questionDate.format(DateTimeFormatter.ofPattern("MMMM d, yyyy")) // Display format (March 26, 2025)


### PR DESCRIPTION
Changes:
- If the user has already answered the QOTD, reopening the app sends them straight to the Answers screen, and the back button is disabled there to prevent navigating back to QOTD
- Set login screen as the first screen the user sees so it is required to login to answer the QOTD
- Prevent user from returning to the login screen using the back button so they don’t have to retype their login
- Removed refresh and custom question button for now

To be fixed:
- QOTD screen flashes for a second before directing user to the answers screen
- Make it so user stays logged in unless they press logout button instead of having to login every time app is reopened
